### PR TITLE
Bump `react-native-screens` to fix FullWindowOverlay issue

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1732,7 +1732,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.9.1):
+  - RNScreens (4.9.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1753,9 +1753,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.9.1)
+    - RNScreens/common (= 4.9.2)
     - Yoga
-  - RNScreens/common (4.9.1):
+  - RNScreens/common (4.9.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2070,7 +2070,7 @@ SPEC CHECKSUMS:
   ReactCommon: a30b578194de911fbe1698efb8247bfe4cb6abff
   RNGestureHandler: f7b3a72c099e1e29b5b81688678bc9108d44057c
   RNReanimated: 195aeabddc3ba4b4ebe1c62190091c6e5a09971d
-  RNScreens: fc78b9b5a1274426d7a59b7d07c272bba13604fa
+  RNScreens: 2e4870e8f9cb4a77e5a51530729f2762868316df
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: be02ca501b03c79d7027a6bbbd0a8db985034f11
 

--- a/rn-app/package.json
+++ b/rn-app/package.json
@@ -18,7 +18,7 @@
     "react-native-gesture-handler": "^2.24.0",
     "react-native-reanimated": "patch:react-native-reanimated@npm%3A3.17.1#~/.yarn/patches/react-native-reanimated-npm-3.17.1-c34570df61.patch",
     "react-native-safe-area-context": "^5.2.0",
-    "react-native-screens": "^4.9.1"
+    "react-native-screens": "^4.9.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/rn-app/yarn.lock
+++ b/rn-app/yarn.lock
@@ -3035,7 +3035,7 @@ __metadata:
     react-native-gesture-handler: "npm:^2.24.0"
     react-native-reanimated: "patch:react-native-reanimated@npm%3A3.17.1#~/.yarn/patches/react-native-reanimated-npm-3.17.1-c34570df61.patch"
     react-native-safe-area-context: "npm:^5.2.0"
-    react-native-screens: "npm:^4.9.1"
+    react-native-screens: "npm:^4.9.2"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:5.0.4"
   languageName: unknown
@@ -8120,16 +8120,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:^4.9.1":
-  version: 4.9.1
-  resolution: "react-native-screens@npm:4.9.1"
+"react-native-screens@npm:^4.9.2":
+  version: 4.9.2
+  resolution: "react-native-screens@npm:4.9.2"
   dependencies:
     react-freeze: "npm:^1.0.0"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/2debc26beea458996873d66741d7d57653507852f67e5cf73011cc28770bb659cbb6b3060e35892ad0cd8db4f4e64198f94bc2085681f1450b6b446253553454
+  checksum: 10c0/ea285f80c2cf836ee87e09daf91d8c085ccc55726cabb556d278cec76d42e8843943f307549a406f373987f958cf3d35b194eac7bb374b1d9c9876dadcec90cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Details

`react-native-screens` v4.9.2 introduced a [PR](https://github.com/software-mansion/react-native-screens/pull/2769) fixing the [issue](https://github.com/software-mansion/react-native-screens/issues/2652)

For more details, see mentioned PR

## Screens and recordings

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/e032d118-4f77-430d-bd83-8f2f2f014dee" />

https://github.com/user-attachments/assets/a76a430c-525d-487b-9aee-1bfb59cb72e4

