### PR TITLE
Add separate navigator and make pushing cards over modals possible

### DIFF
--- a/rn-app/App.tsx
+++ b/rn-app/App.tsx
@@ -116,7 +116,7 @@ function App(): JSX.Element {
                     headerShown: false,
                 }}>
                     <Stack.Screen name="Home" component={HomeScreen} />
-                    <Stack.Screen name="NonModalPage" component={NonModalPage} options={{ presentation: 'card' }}  />
+                    <Stack.Screen name="NonModalPage" component={NonModalPage} />
                     <Stack.Group screenOptions={{
                         presentation: 'modal'
                     }}>

--- a/rn-app/App.tsx
+++ b/rn-app/App.tsx
@@ -52,17 +52,19 @@ const HomeScreen = () => {
 }
 
 const ProfileScreen = () => {
-    const [showModal, setShowModal] = useState<boolean>(false);
+    const navigation = useNavigation();
 
     // ref
     const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
     // callbacks
     const handlePresentModalPress = useCallback(() => {
+        navigation.getParent().setOptions({gestureEnabled: false});
         bottomSheetModalRef.current?.present();
     }, []);
 
     const onDismiss  = useCallback(() => {
+        navigation.getParent().setOptions({gestureEnabled: true});
         bottomSheetModalRef.current?.dismiss();
     }, []);
 

--- a/rn-app/App.tsx
+++ b/rn-app/App.tsx
@@ -86,9 +86,28 @@ const ProfileScreen = () => {
     )
 }
 
+const NonModalPage = () => {
+    const navigation = useNavigation();
+
+    return (
+        <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+            <Text>NonModalPage</Text>
+            <Button title={'Back'} onPress={() => navigation.goBack()}/>
+        </View>
+    );
+}
+
 function App(): JSX.Element {
     const isDarkMode = useColorScheme() === 'dark';
 
+    const ProfileStack = () => {
+        return (
+            <Stack.Navigator screenOptions={{ headerShown: false }}>
+                <Stack.Screen name="ProfileScreen" component={ProfileScreen} />
+                <Stack.Screen name="NonModalPage" component={NonModalPage} />
+            </Stack.Navigator>
+        );
+    };
 
     return (
         <GestureHandlerRootView>
@@ -97,10 +116,11 @@ function App(): JSX.Element {
                     headerShown: false,
                 }}>
                     <Stack.Screen name="Home" component={HomeScreen} />
+                    <Stack.Screen name="NonModalPage" component={NonModalPage} options={{ presentation: 'card' }}  />
                     <Stack.Group screenOptions={{
                         presentation: 'modal'
                     }}>
-                        <Stack.Screen name="Profile" component={ProfileScreen} />
+                        <Stack.Screen name="Profile" component={ProfileStack} />
                     </Stack.Group>
                 </Stack.Navigator>
             </NavigationContainer>

--- a/rn-app/SampleBottomSheetModal.tsx
+++ b/rn-app/SampleBottomSheetModal.tsx
@@ -1,7 +1,7 @@
 import {BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView} from "@gorhom/bottom-sheet";
-import {Dimensions, Text} from "react-native";
-import {FullWindowOverlay} from "react-native-screens";
+import {Button, Dimensions, Text} from "react-native";
 import {RefObject} from "react";
+import {useNavigation} from "@react-navigation/native";
 
 export const SampleBottomSheetModal = ({
     ref, onDismiss
@@ -9,12 +9,13 @@ export const SampleBottomSheetModal = ({
     ref: RefObject<BottomSheetModal>,
     onDismiss: () => void,
 }) => {
+    const navigation = useNavigation();
+
     return ( <BottomSheetModal
         ref={ref}
         enablePanDownToClose={true}
         onDismiss={onDismiss}
         maxDynamicContentSize={Dimensions.get('window').height * 0.9}
-        containerComponent={({children}) => (<FullWindowOverlay>{children}</FullWindowOverlay>)}
         backdropComponent={(props) => <BottomSheetBackdrop
             {...props}
             pressBehavior="close"
@@ -23,6 +24,7 @@ export const SampleBottomSheetModal = ({
         />}
     >
         <BottomSheetScrollView>
+            <Button title={'Go to NonModalPage'} onPress={() => navigation.navigate('NonModalPage')}/>
             <Text>Awesome 🎉</Text>
             <Text>Awesome 🎉</Text>
             <Text>Awesome 🎉</Text>


### PR DESCRIPTION
## Details

To push anything over BottomSheetModal, we need to get rid of `FullWindowOverlay` since it's designed to be the topmost view.

Defining a separate navigator does the trick and allows us to push other views on top of the BottomSheetModal, keeping navigation history unchanged

## Screenshots and recordings


https://github.com/user-attachments/assets/c238812f-5380-4828-ace2-20717416f301

